### PR TITLE
Fix off-by-one error in LZ4 to fix overflow vulnerability

### DIFF
--- a/ext/lz4/lz4.c
+++ b/ext/lz4/lz4.c
@@ -1034,7 +1034,7 @@ _next_match:
                     ip -= matchCode - newMatchCode;
                     assert(newMatchCode < matchCode);
                     matchCode = newMatchCode;
-                    if (unlikely(ip < filledIp)) {
+                    if (unlikely(ip <= filledIp)) {
                         /* We have already filled up to filledIp so if ip ends up less than filledIp
                          * we have positions in the hash table beyond the current position. This is
                          * a problem if we reuse the hash table. So we have to remove these positions


### PR DESCRIPTION
#1 proposes changes to the LZ4 dependency to fix the heap-based buffer overflow vulnerability. This PR provides these changes in accordance with the fix in [LZ4 at commit d7cad81](https://github.com/lz4/lz4/commit/d7cad81093cd805110291f84d64d385557d0ffba)